### PR TITLE
Feat/profile screen

### DIFF
--- a/.idea/appInsightsSettings.xml
+++ b/.idea/appInsightsSettings.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AppInsightsSettings">
+    <option name="selectedTabId" value="Android Vitals" />
+    <option name="tabSettings">
+      <map>
+        <entry key="Firebase Crashlytics">
+          <value>
+            <InsightsFilterSettings>
+              <option name="connection">
+                <ConnectionSetting>
+                  <option name="appId" value="com.capstone.petverse" />
+                  <option name="mobileSdkAppId" value="1:303846479002:android:4f6d19f332f3b31d87bb23" />
+                  <option name="projectId" value="petverse-66f7f" />
+                  <option name="projectNumber" value="303846479002" />
+                </ConnectionSetting>
+              </option>
+              <option name="signal" value="SIGNAL_UNSPECIFIED" />
+              <option name="timeIntervalDays" value="THIRTY_DAYS" />
+              <option name="visibilityType" value="ALL" />
+            </InsightsFilterSettings>
+          </value>
+        </entry>
+      </map>
+    </option>
+  </component>
+</project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -5,7 +5,8 @@
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
+        <option name="gradleHome" value="$PROJECT_DIR$/../../../../../../../gradle-8.6" />
+        <option name="gradleJvm" value="azul-20" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_20" default="true" project-jdk-name="20" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_20" default="true" project-jdk-name="zulu-20" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,6 +23,11 @@
         android:theme="@style/Theme.PetVerse"
         tools:targetApi="31" >
         <activity
+            android:name=".ui.activity.EditProfileActivity"
+            android:exported="false"
+            android:label="@string/title_activity_edit_profile"
+            android:theme="@style/Theme.PetVerse" />
+        <activity
             android:name=".ui.activity.SettingsActivity"
             android:exported="false"
             android:label="@string/title_activity_settings"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
+    xmlns:tools="http://schemas.android.com/tools" >
 
     <uses-permission android:name="android.permission.INTERNET" />
 
@@ -21,7 +21,12 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.PetVerse"
-        tools:targetApi="31">
+        tools:targetApi="31" >
+        <activity
+            android:name=".ui.activity.SettingsActivity"
+            android:exported="false"
+            android:label="@string/title_activity_settings"
+            android:theme="@style/Theme.PetVerse" />
         <activity
             android:name=".ui.activity.UploadPostActivity"
             android:exported="false"
@@ -70,7 +75,7 @@
             android:name=".SplashActivity"
             android:exported="true"
             android:screenOrientation="portrait"
-            android:theme="@style/AppTheme.NoActionBar">
+            android:theme="@style/AppTheme.NoActionBar" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/capstone/petverse/MainActivity.kt
+++ b/app/src/main/java/com/capstone/petverse/MainActivity.kt
@@ -45,6 +45,7 @@ import androidx.navigation.compose.rememberNavController
 import com.capstone.petverse.data.pref.UserPreference
 import com.capstone.petverse.data.pref.dataStore
 import com.capstone.petverse.ui.activity.CameraPreviewScreen
+import com.capstone.petverse.ui.activity.EditProfileScreen
 import com.capstone.petverse.ui.activity.HomeScreen
 import com.capstone.petverse.ui.activity.LikeHistoryActivity
 import com.capstone.petverse.ui.activity.ProfileScreen
@@ -108,20 +109,20 @@ fun PetVerseApp(isCameraPermissionGranted: Boolean, modifier: Modifier = Modifie
     val context = LocalContext.current
 
     Scaffold(
-        bottomBar = { BottomBar(navController) }
+        bottomBar = { if (currentRoute != Screen.EditProfile.route) BottomBar(navController) }
     ) { innerPadding ->
         Column(
             modifier = modifier
                 .padding(innerPadding)
                 .background(Color.White)
         ) {
-            if (currentRoute != Screen.Profile.route && currentRoute != Screen.Upload.route) {
+            if (currentRoute != Screen.Profile.route && currentRoute != Screen.Upload.route && currentRoute != Screen.EditProfile.route) {
                 Search(modifier = Modifier.padding(5.dp))
             }
 
             NavHost(navController, startDestination = Screen.Home.route) {
                 composable(Screen.Home.route) {
-                    val factory = ViewModelFactory.getInstance(LocalContext.current.applicationContext as Application, LocalContext.current)
+                    val factory = ViewModelFactory.getInstance(context.applicationContext as Application, context)
                     val uploadPostViewModel: UploadPostViewModel = viewModel(factory = factory)
                     HomeScreen(viewModel = uploadPostViewModel)
                 }
@@ -132,16 +133,19 @@ fun PetVerseApp(isCameraPermissionGranted: Boolean, modifier: Modifier = Modifie
                     if (isCameraPermissionGranted) {
                         CameraPreviewScreen(navController)
                     } else {
-                        Toast.makeText(LocalContext.current, "Camera permission is required to use this feature", Toast.LENGTH_LONG).show()
+                        Toast.makeText(context, "Camera permission is required to use this feature", Toast.LENGTH_LONG).show()
                     }
                 }
                 composable(Screen.Upload.route) {
-                    val factory = ViewModelFactory.getInstance(LocalContext.current.applicationContext as Application, LocalContext.current)
+                    val factory = ViewModelFactory.getInstance(context.applicationContext as Application, context)
                     val uploadPostViewModel: UploadPostViewModel = viewModel(factory = factory)
                     UploadPostScreen(navController, uploadPostViewModel)
                 }
                 composable(Screen.Profile.route) {
                     ProfileScreen(navController)
+                }
+                composable(Screen.EditProfile.route) {
+                    EditProfileScreen(navController)
                 }
             }
         }
@@ -160,27 +164,27 @@ fun BottomBar(
             BottomBarItem(
                 title = stringResource(R.string.menu_home),
                 icon = Icons.Default.Home,
-                route = "home"
+                route = Screen.Home.route
             ),
             BottomBarItem(
                 title = stringResource(R.string.menu_favorite),
                 icon = Icons.Default.Favorite,
-                route = "favorite"
+                route = Screen.Favorite.route
             ),
             BottomBarItem(
                 title = stringResource(R.string.detection),
                 icon = Icons.Default.PhotoCamera,
-                route = "detection"
+                route = Screen.Detection.route
             ),
             BottomBarItem(
                 title = stringResource(R.string.upload_post),
                 icon = Icons.Default.Upload,
-                route = "upload"
+                route = Screen.Upload.route
             ),
             BottomBarItem(
                 title = stringResource(R.string.menu_profile),
                 icon = Icons.Default.AccountCircle,
-                route = "profile"
+                route = Screen.Profile.route
             ),
         )
         navigationItems.forEach { item ->

--- a/app/src/main/java/com/capstone/petverse/MainActivity.kt
+++ b/app/src/main/java/com/capstone/petverse/MainActivity.kt
@@ -25,7 +25,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -48,13 +47,13 @@ import com.capstone.petverse.data.pref.dataStore
 import com.capstone.petverse.ui.activity.CameraPreviewScreen
 import com.capstone.petverse.ui.activity.HomeScreen
 import com.capstone.petverse.ui.activity.LikeHistoryActivity
+import com.capstone.petverse.ui.activity.ProfileScreen
 import com.capstone.petverse.ui.activity.UploadPostScreen
 import com.capstone.petverse.ui.activity.WelcomeActivity
 import com.capstone.petverse.ui.components.Search
 import com.capstone.petverse.ui.model.BottomBarItem
 import com.capstone.petverse.ui.model.Screen
 import com.capstone.petverse.ui.theme.PetVerseTheme
-import com.capstone.petverse.ui.viewmodel.SignupViewModel
 import com.capstone.petverse.ui.viewmodel.UploadPostViewModel
 import com.capstone.petverse.ui.viewmodel.ViewModelFactory
 import kotlinx.coroutines.flow.first
@@ -116,13 +115,13 @@ fun PetVerseApp(isCameraPermissionGranted: Boolean, modifier: Modifier = Modifie
                 .padding(innerPadding)
                 .background(Color.White)
         ) {
-            if (currentRoute != Screen.Upload.route) {
+            if (currentRoute != Screen.Profile.route && currentRoute != Screen.Upload.route) {
                 Search(modifier = Modifier.padding(5.dp))
             }
+
             NavHost(navController, startDestination = Screen.Home.route) {
                 composable(Screen.Home.route) {
-
-                    val factory = ViewModelFactory.getInstance(context.applicationContext as Application, context)
+                    val factory = ViewModelFactory.getInstance(LocalContext.current.applicationContext as Application, LocalContext.current)
                     val uploadPostViewModel: UploadPostViewModel = viewModel(factory = factory)
                     HomeScreen(viewModel = uploadPostViewModel)
                 }
@@ -133,19 +132,16 @@ fun PetVerseApp(isCameraPermissionGranted: Boolean, modifier: Modifier = Modifie
                     if (isCameraPermissionGranted) {
                         CameraPreviewScreen(navController)
                     } else {
-                        Toast.makeText(context, "Camera permission is required to use this feature", Toast.LENGTH_LONG).show()
+                        Toast.makeText(LocalContext.current, "Camera permission is required to use this feature", Toast.LENGTH_LONG).show()
                     }
                 }
                 composable(Screen.Upload.route) {
-                    val factory = ViewModelFactory.getInstance(context.applicationContext as Application, context)
+                    val factory = ViewModelFactory.getInstance(LocalContext.current.applicationContext as Application, LocalContext.current)
                     val uploadPostViewModel: UploadPostViewModel = viewModel(factory = factory)
                     UploadPostScreen(navController, uploadPostViewModel)
                 }
                 composable(Screen.Profile.route) {
-                    val viewModel: SignupViewModel = viewModel()
-                    CompositionLocalProvider(LocalContext provides LocalContext.current) {
-                        // ProfileActivity(viewModel = viewModel)
-                    }
+                    ProfileScreen(navController)
                 }
             }
         }

--- a/app/src/main/java/com/capstone/petverse/ui/activity/EditProfileActivity.kt
+++ b/app/src/main/java/com/capstone/petverse/ui/activity/EditProfileActivity.kt
@@ -1,0 +1,158 @@
+package com.capstone.petverse.ui.activity
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+import coil.compose.AsyncImage
+import com.capstone.petverse.R
+import com.capstone.petverse.ui.theme.PetVerseTheme
+
+@Composable
+fun EditProfileScreen(navController: NavController) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = stringResource(id = R.string.edit_profile),
+                onBackClick = { navController.navigateUp() }
+            )
+        },
+        content = { paddingValues ->
+            EditProfileContent(modifier = Modifier.padding(paddingValues))
+        }
+    )
+}
+
+@Composable
+fun EditProfileContent(modifier: Modifier = Modifier) {
+    var name by remember { mutableStateOf("") }
+    var username by remember { mutableStateOf("") }
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(20.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Spacer(modifier = Modifier.height(16.dp))
+        AsyncImage(
+            model = "https://via.placeholder.com/150",
+            contentDescription = "Profile Picture",
+            modifier = Modifier
+                .size(100.dp)
+                .clip(CircleShape)
+                .clickable { /* TODO: Handle profile picture change */ },
+            contentScale = ContentScale.Crop
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = "Change profile picture",
+            color = colorResource(id = R.color.colorPrimary),
+            modifier = Modifier.clickable { /* TODO: Handle profile picture change */ }
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Column(horizontalAlignment = Alignment.Start) {
+            Text(
+                text = stringResource(R.string.name),
+                fontSize = 14.sp,
+                fontWeight = FontWeight.SemiBold,
+                fontFamily = FontFamily(Font(R.font.inter_bold, FontWeight.Bold)),
+                color = colorResource(id = R.color.colorPrimaryDark)
+            )
+            Spacer(modifier = Modifier.height(10.dp))
+            OutlinedTextField(
+                modifier = Modifier.fillMaxWidth(),
+                value = name,
+                onValueChange = { name = it },
+                singleLine = true,
+                trailingIcon = {
+                    if (name.isNotBlank())
+                        IconButton(onClick = { name = "" }) {
+                            Icon(imageVector = Icons.Default.Clear, contentDescription = "Clear name")
+                        }
+                },
+                colors = OutlinedTextFieldDefaults.colors(
+                    focusedBorderColor = colorResource(id = R.color.colorPrimary),
+                    unfocusedBorderColor = colorResource(id = R.color.colorPrimaryDark),
+                    focusedTextColor = Color.Black,
+                    unfocusedTextColor = Color.Black
+                )
+            )
+
+            Spacer(modifier = Modifier.height(10.dp))
+
+            Text(
+                text = stringResource(R.string.username),
+                fontSize = 14.sp,
+                fontWeight = FontWeight.SemiBold,
+                fontFamily = FontFamily(Font(R.font.inter_bold, FontWeight.Bold)),
+                color = colorResource(id = R.color.colorPrimaryDark)
+            )
+            Spacer(modifier = Modifier.height(10.dp))
+            OutlinedTextField(
+                modifier = Modifier.fillMaxWidth(),
+                value = username,
+                onValueChange = { username = it },
+                singleLine = true,
+                trailingIcon = {
+                    if (username.isNotBlank())
+                        IconButton(onClick = { username = "" }) {
+                            Icon(imageVector = Icons.Default.Clear, contentDescription = "Clear username")
+                        }
+                },
+                colors = OutlinedTextFieldDefaults.colors(
+                    focusedBorderColor = colorResource(id = R.color.colorPrimary),
+                    unfocusedBorderColor = colorResource(id = R.color.colorPrimaryDark),
+                    focusedTextColor = Color.Black,
+                    unfocusedTextColor = Color.Black
+                )
+            )
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+        Button(
+            onClick = { /* TODO: Handle update profile */ },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+                .height(50.dp),
+            colors = ButtonDefaults.buttonColors(containerColor = colorResource(id = R.color.colorPrimary)),
+            shape = RoundedCornerShape(8.dp)
+        ) {
+            Text(
+                text = "Update",
+                fontWeight = FontWeight.Bold,
+                color = Color.White
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewEditProfileScreen() {
+    PetVerseTheme {
+        val navController = rememberNavController()
+        EditProfileScreen(navController = navController)
+    }
+}

--- a/app/src/main/java/com/capstone/petverse/ui/activity/ProfileActivity.kt
+++ b/app/src/main/java/com/capstone/petverse/ui/activity/ProfileActivity.kt
@@ -1,37 +1,40 @@
+package com.capstone.petverse.ui.activity
+
+import androidx.compose.animation.*
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Settings
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarDefaults
-import androidx.compose.runtime.Composable
+import androidx.compose.material3.*
+import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.capstone.petverse.R // Ensure this is correct
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+import com.capstone.petverse.R
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ProfileScreen() {
+fun ProfileScreen(navController: NavController) {
     Scaffold(
-        topBar = { ProfileTopBar() },
+        topBar = { ProfileTopBar(navController) },
         content = { paddingValues ->
             BodyContent(modifier = Modifier.padding(paddingValues))
         }
@@ -40,12 +43,12 @@ fun ProfileScreen() {
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ProfileTopBar() {
+fun ProfileTopBar(navController: NavController) {
     TopAppBar(
         title = {},
-        colors = TopAppBarDefaults.smallTopAppBarColors(containerColor = Color.White),
+        colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.White),
         actions = {
-            IconButton(onClick = { /* Settings action */ }) {
+            IconButton(onClick = { /*TODO: navigate to SettingsScreen*/ }) {
                 Icon(Icons.Filled.Settings, contentDescription = "Settings")
             }
         }
@@ -57,23 +60,31 @@ fun BodyContent(modifier: Modifier = Modifier) {
     Column(
         modifier = modifier
             .fillMaxSize()
-            .padding(8.dp)
+            .padding(8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
     ) {
         ProfileSection()
         Spacer(modifier = Modifier.height(8.dp))
         ProfileStats()
         Spacer(modifier = Modifier.height(8.dp))
         Button(
-            onClick = { /* Edit profile action */ },
-            modifier = Modifier
-                .fillMaxWidth()
-                .clip(RoundedCornerShape(8.dp)),
-            colors = ButtonDefaults.buttonColors(containerColor = Color.LightGray)
+            onClick = { /* TODO: Handle edit profile action */ },
+            colors = ButtonDefaults.buttonColors(
+                containerColor = Color.White,
+                contentColor = colorResource(id = R.color.colorTextBlack)
+            ),
+            border = BorderStroke(1.dp, colorResource(id = R.color.colorTextBlack)),
+            shape = RoundedCornerShape(8.dp),
+            modifier = Modifier.padding(8.dp)
         ) {
-            Text("Edit Profile")
+            Text(
+                text = "Edit Profile",
+                fontSize = 16.sp,
+                fontWeight = FontWeight.Bold
+            )
         }
-        Spacer(modifier = Modifier.height(16.dp))
-        PhotoGrid()
+        Spacer(modifier = Modifier.height(8.dp))
+        ProfileTab()
     }
 }
 
@@ -84,7 +95,7 @@ fun ProfileSection() {
         modifier = Modifier.fillMaxWidth()
     ) {
         Image(
-            painter = painterResource(id = R.drawable.account_circle_24), // Ensure this resource exists
+            painter = painterResource(id = R.drawable.account_circle_24),
             contentDescription = "Profile Picture",
             modifier = Modifier
                 .size(100.dp)
@@ -99,32 +110,160 @@ fun ProfileSection() {
 @Composable
 fun ProfileStats() {
     Row(
+        horizontalArrangement = Arrangement.SpaceEvenly,
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp),
-        horizontalArrangement = Arrangement.SpaceBetween
+            .padding(horizontal = 16.dp)
     ) {
-        ProfileStat("300", "Followers")
-        ProfileStat("200", "Following")
-        ProfileStat("60", "Likes")
+        ProfileStatItem(value = "300", label = "Followers")
+        VerticalDivider(
+            color = Color.Gray,
+            modifier = Modifier
+                .height(40.dp)
+                .width(1.dp)
+                .align(Alignment.CenterVertically)
+        )
+        ProfileStatItem(value = "200", label = "Following")
+        VerticalDivider(
+            color = Color.Gray,
+            modifier = Modifier
+                .height(40.dp)
+                .width(1.dp)
+                .align(Alignment.CenterVertically)
+        )
+        ProfileStatItem(value = "60", label = "Likes")
     }
 }
 
 @Composable
-fun ProfileStat(number: String, label: String) {
-    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-        Text(number, fontWeight = FontWeight.Bold)
-        Text(label)
+fun ProfileStatItem(value: String, label: String) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier.width(80.dp)
+    ) {
+        Text(text = value, fontWeight = FontWeight.Bold)
+        Text(text = label)
     }
 }
 
 @Composable
-fun PhotoGrid() {
-    // Implement a grid layout using LazyVerticalGrid or a custom grid logic
+fun ProfileTab() {
+    var selectedTabIndex by remember { mutableIntStateOf(0) }
+
+    TabRow(
+        selectedTabIndex = selectedTabIndex,
+        indicator = { tabPositions ->
+            TabRowDefaults.SecondaryIndicator(
+                Modifier
+                    .tabIndicatorOffset(tabPositions[selectedTabIndex])
+                    .fillMaxWidth()
+                    .background(colorResource(id = R.color.colorPrimary))
+            )
+        }
+    ) {
+        Tab(
+            selected = selectedTabIndex == 0,
+            onClick = { selectedTabIndex = 0 },
+            modifier = Modifier.height(42.dp)
+        ) {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                Image(
+                    painter = painterResource(id = R.drawable.home_outlined),
+                    contentDescription = null,
+                    modifier = Modifier.size(24.dp)
+                )
+            }
+        }
+        Tab(
+            selected = selectedTabIndex == 1,
+            onClick = { selectedTabIndex = 1 },
+            modifier = Modifier.height(42.dp)
+        ) {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                Image(
+                    painter = painterResource(id = R.drawable.home_outlined),
+                    contentDescription = null,
+                    modifier = Modifier.size(24.dp)
+                )
+            }
+        }
+    }
+
+    Spacer(modifier = Modifier.height(8.dp))
+
+    AnimatedContent(
+        targetState = selectedTabIndex,
+        label = "ProfileTabs", // Set the label for better inspection
+        transitionSpec = {
+            if (targetState > initialState) {
+                slideInHorizontally { width -> width } + fadeIn(tween(300)) togetherWith
+                        slideOutHorizontally { width -> -width } + fadeOut(tween(300))
+            } else {
+                slideInHorizontally { width -> -width } + fadeIn(tween(300)) togetherWith
+                        slideOutHorizontally { width -> width } + fadeOut(tween(300))
+            }.using(SizeTransform(false))
+        }
+    ) { index ->
+        when (index) {
+            0 -> ContentPost()
+            1 -> AdoptionPost()
+        }
+    }
+}
+
+@Composable
+fun ContentPost() {
+    val photos = remember { listOf(R.drawable.pet_adoption, R.drawable.pet_adoption, R.drawable.pet_adoption, R.drawable.pet_adoption, R.drawable.pet_adoption, R.drawable.pet_adoption, R.drawable.pet_adoption, R.drawable.pet_adoption) }
+    LazyVerticalGrid(
+        columns = GridCells.Fixed(3),
+        contentPadding = PaddingValues(4.dp),
+        modifier = Modifier.fillMaxSize()
+    ) {
+        items(photos.size) { index ->
+            Image(
+                painter = painterResource(id = photos[index]),
+                contentDescription = null,
+                modifier = Modifier
+                    .padding(4.dp)
+                    .size(100.dp)
+                    .clip(RoundedCornerShape(8.dp)),
+                contentScale = ContentScale.Crop
+            )
+        }
+    }
+}
+
+@Composable
+fun AdoptionPost() {
+    val photos = remember { listOf(R.drawable.pet_adoption, R.drawable.pet_adoption, R.drawable.pet_adoption, R.drawable.pet_adoption, R.drawable.pet_adoption, R.drawable.pet_adoption, R.drawable.pet_adoption, R.drawable.pet_adoption) }
+    LazyVerticalGrid(
+        columns = GridCells.Fixed(3),
+        contentPadding = PaddingValues(4.dp),
+        modifier = Modifier.fillMaxSize()
+    ) {
+        items(photos.size) { index ->
+            Image(
+                painter = painterResource(id = photos[index]),
+                contentDescription = null,
+                modifier = Modifier
+                    .padding(4.dp)
+                    .size(100.dp)
+                    .clip(RoundedCornerShape(8.dp)),
+                contentScale = ContentScale.Crop
+            )
+        }
+    }
 }
 
 @Preview(showBackground = true)
 @Composable
 fun PreviewProfileScreen() {
-    ProfileScreen()
+    val navController = rememberNavController()
+    ProfileScreen(navController = navController)
 }

--- a/app/src/main/java/com/capstone/petverse/ui/activity/ProfileActivity.kt
+++ b/app/src/main/java/com/capstone/petverse/ui/activity/ProfileActivity.kt
@@ -1,5 +1,6 @@
 package com.capstone.petverse.ui.activity
 
+import android.content.Intent
 import androidx.compose.animation.*
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.BorderStroke
@@ -21,6 +22,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
@@ -34,21 +36,24 @@ import com.capstone.petverse.R
 @Composable
 fun ProfileScreen(navController: NavController) {
     Scaffold(
-        topBar = { ProfileTopBar(navController) },
+        topBar = { ProfileTopBar() },
         content = { paddingValues ->
-            BodyContent(modifier = Modifier.padding(paddingValues))
+            BodyContent(modifier = Modifier.padding(paddingValues), navController)
         }
     )
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ProfileTopBar(navController: NavController) {
+fun ProfileTopBar() {
+    val context = LocalContext.current
     TopAppBar(
         title = {},
         colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.White),
         actions = {
-            IconButton(onClick = { /*TODO: navigate to SettingsScreen*/ }) {
+            IconButton(onClick = {
+                context.startActivity(Intent(context, SettingsActivity::class.java))
+            }) {
                 Icon(Icons.Filled.Settings, contentDescription = "Settings")
             }
         }
@@ -56,7 +61,7 @@ fun ProfileTopBar(navController: NavController) {
 }
 
 @Composable
-fun BodyContent(modifier: Modifier = Modifier) {
+fun BodyContent(modifier: Modifier = Modifier, navController: NavController) {
     Column(
         modifier = modifier
             .fillMaxSize()
@@ -68,7 +73,7 @@ fun BodyContent(modifier: Modifier = Modifier) {
         ProfileStats()
         Spacer(modifier = Modifier.height(8.dp))
         Button(
-            onClick = { /* TODO: Handle edit profile action */ },
+            onClick = { navController.navigate("edit_profile") },
             colors = ButtonDefaults.buttonColors(
                 containerColor = Color.White,
                 contentColor = colorResource(id = R.color.colorTextBlack)
@@ -103,7 +108,8 @@ fun ProfileSection() {
                 .border(2.dp, Color.Black, CircleShape),
             contentScale = ContentScale.Crop
         )
-        Text("Username", fontSize = 24.sp, fontWeight = FontWeight.Bold)
+        Text("Name", fontSize = 18.sp, fontWeight = FontWeight.Bold)
+        Text("@username", fontSize = 15.sp, fontWeight = FontWeight.Medium)
     }
 }
 
@@ -199,7 +205,7 @@ fun ProfileTab() {
 
     AnimatedContent(
         targetState = selectedTabIndex,
-        label = "ProfileTabs", // Set the label for better inspection
+        label = "ProfileTabs",
         transitionSpec = {
             if (targetState > initialState) {
                 slideInHorizontally { width -> width } + fadeIn(tween(300)) togetherWith

--- a/app/src/main/java/com/capstone/petverse/ui/activity/SettingsActivity.kt
+++ b/app/src/main/java/com/capstone/petverse/ui/activity/SettingsActivity.kt
@@ -1,0 +1,47 @@
+package com.capstone.petverse.ui.activity
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.capstone.petverse.ui.activity.ui.theme.PetVerseTheme
+
+class SettingsActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+        setContent {
+            PetVerseTheme {
+                Scaffold( modifier = Modifier.fillMaxSize() ) { innerPadding ->
+                    Greeting(
+                        name = "Android",
+                        modifier = Modifier.padding(innerPadding)
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun Greeting(name: String, modifier: Modifier = Modifier) {
+    Text(
+        text = "Hello $name!",
+        modifier = modifier
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+fun GreetingPreview() {
+    PetVerseTheme {
+        Greeting("Android")
+    }
+}

--- a/app/src/main/java/com/capstone/petverse/ui/activity/SettingsActivity.kt
+++ b/app/src/main/java/com/capstone/petverse/ui/activity/SettingsActivity.kt
@@ -3,27 +3,46 @@ package com.capstone.petverse.ui.activity
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowForwardIos
+import androidx.compose.material.icons.filled.ArrowOutward
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.capstone.petverse.R
 import com.capstone.petverse.ui.activity.ui.theme.PetVerseTheme
 
 class SettingsActivity : ComponentActivity() {
+    private val interFamily = FontFamily(
+        Font(R.font.inter_medium, FontWeight.Medium),
+        Font(R.font.inter_semibold, FontWeight.SemiBold)
+    )
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
         setContent {
             PetVerseTheme {
-                Scaffold( modifier = Modifier.fillMaxSize() ) { innerPadding ->
-                    Greeting(
-                        name = "Android",
-                        modifier = Modifier.padding(innerPadding)
-                    )
+                SettingsScreen(interFamily = interFamily) {
+                    finish()  // Finish activity on back click
                 }
             }
         }
@@ -31,17 +50,106 @@ class SettingsActivity : ComponentActivity() {
 }
 
 @Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier
+fun SettingsScreen(interFamily: FontFamily = FontFamily.Default, onBackClick: () -> Unit) {
+    Scaffold(
+        topBar = { TopAppBar(title = stringResource(id = R.string.settings), onBackClick = onBackClick) },
+        content = { innerPadding ->
+            SettingsContent(interFamily = interFamily, modifier = Modifier.padding(innerPadding))
+        }
     )
+}
+
+@Composable
+fun SettingsContent(interFamily: FontFamily, modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        SettingsSection(title = stringResource(R.string.account), interFamily = interFamily) {
+            SettingsItem(text = stringResource(R.string.account_management), onClick = { /* TODO */ }, interFamily = interFamily)
+            SettingsItem(text = stringResource(R.string.select_language), onClick = { /* TODO */ }, interFamily = interFamily)
+            DarkModeToggle(interFamily = interFamily)
+        }
+
+        SettingsSection(title = stringResource(R.string.deletion), interFamily = interFamily) {
+            SettingsItem(text = stringResource(R.string.delete_account), onClick = { /* TODO */ }, interFamily = interFamily)
+        }
+
+        SettingsSection(title = stringResource(R.string.support), interFamily = interFamily) {
+            SettingsItem(text = stringResource(R.string.help_center), onClick = { /* TODO */ }, isExternalLink = true, interFamily = interFamily)
+            SettingsItem(text = stringResource(R.string.terms_of_service), onClick = { /* TODO */ }, isExternalLink = true, interFamily = interFamily)
+            SettingsItem(text = stringResource(R.string.privacy_policy), onClick = { /* TODO */ }, isExternalLink = true, interFamily = interFamily)
+        }
+    }
+}
+
+@Composable
+fun SettingsSection(title: String, interFamily: FontFamily, content: @Composable () -> Unit) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = title,
+            fontFamily = interFamily,
+            fontWeight = FontWeight.Medium,
+            fontSize = 15.sp,
+            modifier = Modifier.padding(vertical = 8.dp)
+        )
+        content()
+        HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+    }
+}
+
+@Composable
+fun SettingsItem(text: String, onClick: () -> Unit, interFamily: FontFamily, isExternalLink: Boolean = false) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onClick() }
+            .padding(vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(
+            text = text,
+            fontFamily = interFamily,
+            fontWeight = FontWeight.SemiBold,
+            fontSize = 17.sp
+        )
+        Icon(
+            imageVector = if (isExternalLink) Icons.Filled.ArrowOutward else Icons.AutoMirrored.Filled.ArrowForwardIos,
+            contentDescription = null
+        )
+    }
+}
+
+@Composable
+fun DarkModeToggle(interFamily: FontFamily) {
+    var isDarkModeEnabled by remember { mutableStateOf(false) }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(
+            text = stringResource(R.string.enable_dark_mode),
+            fontFamily = interFamily,
+            fontWeight = FontWeight.Medium,
+            fontSize = 15.sp
+        )
+        Switch(
+            checked = isDarkModeEnabled,
+            onCheckedChange = { isDarkModeEnabled = it }
+        )
+    }
 }
 
 @Preview(showBackground = true)
 @Composable
-fun GreetingPreview() {
+fun PreviewSettingsScreen() {
     PetVerseTheme {
-        Greeting("Android")
+        SettingsScreen(onBackClick = {})
     }
 }

--- a/app/src/main/java/com/capstone/petverse/ui/activity/TopAppBar.kt
+++ b/app/src/main/java/com/capstone/petverse/ui/activity/TopAppBar.kt
@@ -1,0 +1,63 @@
+package com.capstone.petverse.ui.activity
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.capstone.petverse.R
+
+val interBold = FontFamily(
+    Font(R.font.inter_bold, FontWeight.Bold)
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TopAppBar(
+    title: String,
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    CenterAlignedTopAppBar(
+        modifier = modifier.padding(horizontal = 12.dp),
+        title = {
+            Text(
+                text = title,
+                style = TextStyle(
+                    fontFamily = interBold,
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 20.sp
+                )
+            )
+        },
+        navigationIcon = {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                contentDescription = stringResource(R.string.back),
+                modifier = modifier.clickable {
+                    onBackClick()
+                }
+            )
+        }
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Preview
+@Composable
+fun PreviewTopAppBar() {
+    TopAppBar(title = stringResource(R.string.settings), onBackClick = {})
+}

--- a/app/src/main/java/com/capstone/petverse/ui/model/Screens.kt
+++ b/app/src/main/java/com/capstone/petverse/ui/model/Screens.kt
@@ -6,4 +6,5 @@ sealed class Screen(val route: String) {
     object Upload : Screen("upload")
     object Detection : Screen("detection")
     object Profile : Screen("profile")
+    object EditProfile : Screen("edit_profile")
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,5 +32,19 @@
     <string name="title_activity_upload_postt">UploadPosttActivity</string>
     <string name="title_activity_main">MainActivity</string>
     <string name="detection">Detection</string>
+    <string name="title_activity_settings">SettingsActivity</string>
 
+    <string name="menu">Menu</string>
+    <string name="settings">Settings</string>
+    <string name="back">Back</string>
+    <string name="account">Account</string>
+    <string name="account_management">Account Management</string>
+    <string name="select_language">Select Language</string>
+    <string name="enable_dark_mode">Enable Dark Mode</string>
+    <string name="deletion">Deletion</string>
+    <string name="delete_account">Delete Your Account</string>
+    <string name="support">Support</string>
+    <string name="help_center">Help Center</string>
+    <string name="terms_of_service">Terms of Service</string>
+    <string name="privacy_policy">Privacy Policy</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -47,4 +47,9 @@
     <string name="help_center">Help Center</string>
     <string name="terms_of_service">Terms of Service</string>
     <string name="privacy_policy">Privacy Policy</string>
+    <string name="title_activity_edit_profile">EditProfileActivity</string>
+
+    <string name="edit_profile">Edit Profile</string>
+    <string name="name">Name</string>
+    <string name="username">Username</string>
 </resources>


### PR DESCRIPTION
## Changes Overview
- Added a new `ProfileScreen` composable that includes:
  - A profile section with user information.
  - User statistics (followers, following, likes).
  - Tabs for navigating between "Posts" and "Adoptions" with sliding animations.
  - Integrated navigation from "Settings" button to the SettingsScreen.
  - Making the SettingsScreen.
  - Integrated navigation from "Edit Profile" button to the EditProfileScreen.
  - Making the EditProfileScreen.


## Notes
- All of the clickable on the SettingsScreen is not yet implemented (except onBackClick).
- All of the clickable on the EditProfileScreen is not yet implemented (except onBackClick).
- The user profile API is not yet implemented.